### PR TITLE
Fix podspec

### DIFF
--- a/NKCore.podspec
+++ b/NKCore.podspec
@@ -6,7 +6,7 @@ s.description  = "NodeKit is the universal, open-source, embedded engine that pr
 s.homepage     = "https://github.com/nodekit-io/nodekit"
 s.license      = { :type => 'APACHE-2', :file => 'LICENSE' }
 s.author       = { "OffGrid Networks" => 'admin@offgridn.com' }
-s.source       = { :git => "https://github.com/nodekit-io/nodekit-darwin.git" }
+s.source       = { :git => "https://github.com/nodekit-io/nodekit-darwin.git", :tag => "v0.8.1" }
 
 s.ios.deployment_target = '9.0'
 s.osx.deployment_target = '10.11'

--- a/NKElectro.podspec
+++ b/NKElectro.podspec
@@ -6,7 +6,7 @@ s.description  = "NodeKit is the universal, open-source, embedded engine that pr
 s.homepage     = "https://github.com/nodekit-io/nodekit"
 s.license      = { :type => 'APACHE-2', :file => 'LICENSE' }
 s.author       = { "OffGrid Networks" => 'admin@offgridn.com' }
-s.source       = { :git => "https://github.com/nodekit-io/nodekit-darwin.git" }
+s.source       = { :git => "https://github.com/nodekit-io/nodekit-darwin.git", :tag => "v0.8.1" }
 
 s.ios.deployment_target = '9.0'
 s.osx.deployment_target = '10.11'

--- a/NKScripting.podspec
+++ b/NKScripting.podspec
@@ -6,7 +6,7 @@ s.description  = "NodeKit is the universal, open-source, embedded engine that pr
 s.homepage     = "https://github.com/nodekit-io/nodekit"
 s.license      = { :type => 'APACHE-2', :file => 'LICENSE' }
 s.author       = { "OffGrid Networks" => 'admin@offgridn.com' }
-s.source       = { :git => "https://github.com/nodekit-io/nodekit-darwin.git" }
+s.source       = { :git => "https://github.com/nodekit-io/nodekit-darwin.git", :tag => "v0.8.1" }
 
 s.ios.deployment_target = '9.0'
 s.osx.deployment_target = '10.11'

--- a/NodeKit.podspec
+++ b/NodeKit.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/nodekit-io/nodekit"
   s.license      = { :type => 'APACHE-2', :file => 'LICENSE' }
   s.author       = { "OffGrid Networks" => 'admin@offgridn.com' }
-  s.source       = { :git => "https://github.com/nodekit-io/nodekit-darwin.git" }
+  s.source       = { :git => "https://github.com/nodekit-io/nodekit-darwin.git", :tag => "v0.8.1" }
 
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.11'


### PR DESCRIPTION
Fix podSpec to pull from correctly tagged commit, currently it pulls from master.

I'm using `pod 'NodeKit'` and I'm getting errors like `Type 'NSAlertStyle' has no member 'Informational'` because it pulling from [this commit](https://github.com/nodekit-io/nodekit-darwin/commit/f22ca0a4bb1de8f4bff8f631a295754d75cb0272)
